### PR TITLE
"Fix auth error handling in DiaryEditor and clean up fetchNote"

### DIFF
--- a/web/src/components/DiaryEditor.vue
+++ b/web/src/components/DiaryEditor.vue
@@ -40,20 +40,20 @@ const extensions = createExtensions();
 const content = ref({});
 const noteJsonRef = ref(null);
 const queryKey = computed(() => ['diaryContent', props.date]);
-const { data: noteData, isLoading } = useQuery({
+const { data: noteData, isLoading, error: getNoteError } = useQuery({
   queryKey: queryKey,
   queryFn: () => fetchNote(props.date),
-  // TODO: fix the onError removed from the useQuery issue
-  onError: (error) => {
-    if (error.response && error.response.status === 401) {
-      // Use the correct router method in the Vue 3 setup
-      router.push({ name: 'login' });
-    }
-    console.error('Error fetching diary:', error);
-  },
+  retry: false,
   staleTime: 1000 * 60 * 5,
 });
 
+watch(getNoteError, (error) => {
+  if (error.response && error.response.status === 401) {
+    // Use the correct router method in the Vue 3 setup
+    router.push({ name: 'login' });
+  }
+  console.error('Error fetching diary:', error);
+})
 
 watch(noteData, (newData) => {
   if (newData) {

--- a/web/src/services/note.ts
+++ b/web/src/services/note.ts
@@ -161,7 +161,7 @@ const fetchNote = async (noteId: string): Promise<DiaryEntry | undefined> => {
         let cachedNote = await db.get('notes', noteId);
         if (navigator.onLine) {
                 try {
-                        const response = await axiosRequest(`/api/diary/${noteId}`, 'GET', null);
+                const response = await axiosRequest(`/api/diary/${noteId}`, 'GET', null);
                         if (response) {
                                 cachedNote = response;
                                 db.put('notes', response);


### PR DESCRIPTION
This commit:
1. Moves 401 error handling from useQuery's deprecated onError to a watch on getNoteError
2. Removes retries for failed note fetches
3. Cleans up indentation in fetchNote service
4. Maintains existing functionality while using current best practices