### PR TITLE
Fix: fetchNote returns default empty entry instead of undefined

### DIFF
--- a/web/src/services/note.ts
+++ b/web/src/services/note.ts
@@ -114,7 +114,7 @@ const saveNote = async (note: DiaryEntry) => {
         return localNote;
 };
 
-const fetchNote = async (noteId: string): Promise<DiaryEntry | undefined> => {
+const fetchNote = async (noteId: string): Promise<DiaryEntry> => {
         console.log("fetching note", noteId);
         const db = await openDatabase();
         let cachedNote = await db.get('notes', noteId);
@@ -138,7 +138,16 @@ const fetchNote = async (noteId: string): Promise<DiaryEntry | undefined> => {
                         console.error(getApiErrorMessage(error, "Network error"));
                 }
         }
-        return cachedNote
+        // Return cached note or create a default empty entry
+        if (cachedNote) {
+                return cachedNote;
+        }
+        // Return a default empty diary entry for new notes
+        return {
+                noteId,
+                note: '',
+                dirty: false,
+        };
 };
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
Fixed `fetchNote` in `services/note.ts` to always return a valid `DiaryEntry` instead of potentially returning `undefined`.

## Problem
When a note didn't exist (new note or offline), `fetchNote` returned `undefined`, which could cause issues in consumers like `DiaryEditor.vue`.

## Solution
- Changed return type from `Promise<DiaryEntry | undefined>` to `Promise<DiaryEntry>`
- Returns a default empty diary entry when note doesn't exist:
  ```typescript
  {
    noteId,
    note: '',
    dirty: false,
  }
  ```

## Benefits
- Prevents undefined errors in consumers
- Better UX for new notes - editor shows empty content instead of nothing
- Type-safe: no need to handle undefined case

## Testing
- Create a new note (date that doesn't exist)
- Verify editor shows empty content
- Offline mode: verify new notes still work